### PR TITLE
Small bugfixes for release 1 (xarray_plots, region_select, etc.)

### DIFF
--- a/docs/appendix/yaml.rst
+++ b/docs/appendix/yaml.rst
@@ -348,7 +348,7 @@ with the columns in the observation file), choose ``auto-region:epa`` or
 approximation, since it assumes perfect, rectangular lonlat boxes.
 If you only need a rectangular, lonlat box which does not cross the antimeridian, you can use
 ``custom:box``, which needs to be combined with the ``domain_info`` parameter and
-a box of ``bounds: [minlat, minlon, maxlat, maxlon]``. See :doc:`/users_guide/region_selection` for examples.
+a box of ``bounds: [minlon, maxlon, minlat, maxlat]``. See :doc:`/users_guide/region_selection` for examples.
 
 If you have ``regionmask`` installed, you can also use it for advanced region support.
 These regions can be arbitrary, and its use require providing ``domain_type`` parameters starting

--- a/docs/users_guide/region_selection.rst
+++ b/docs/users_guide/region_selection.rst
@@ -13,7 +13,7 @@ as `custom:box`.
 `Giorgi` regions and a rough, rectangular approximation to `EPA` regions have already been hardcoded into
 MELODIES-MONET.
 In the case of `EPA` regions, be aware that the approximation is quite rough to force it into a rectangular lonlat box, and although it is probably sufficient for plotting maps, it can lead to errors if used for anything else.
-If `custom:box` is selected a lonlat box in the form of `bounds: [minlat, minlon, maxlat, maxlon]` needs to be provided in `domain_info` (see example below).
+If `custom:box` is selected a lonlat box in the form of `bounds: [minlon, maxlon, minlat, maxlat]` needs to be provided in `domain_info` (see example below).
 `custom:box` has, however, some limitations: `minlon` and `maxlon` need to be in the range of `[-180, 180]`, and the box cannot cross the antimeridian.
 
 A third, and more sophisticated option, consists in utilizing the optional dependency `regionmask <https://regionmask.readthedocs.io/en/stable/>`__.
@@ -34,7 +34,7 @@ An example of the plotting part of an arbitrary plot for eact type of region is 
   domain_name: ["CONUS", "model", "CO",          "R8",        "CNA",                "R8box",      "onepoly",        "twopolys",       "colorado",      "denverfile",  "denverurl"]
   domain_info:
     R8box: 
-      bounds: [39.8, -105.30, 40.2, -105.1]
+      bounds: [-105.30, -105.1, 39.8, 40.2]
     onepoly:
       mask_info: [[-104.968, 39.47], [-104.618, 39.75], [-104.968, 40.06], [-105.32, 39.75]]
     twopolys: 

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -2736,7 +2736,7 @@ class analysis:
                         elif plot_type.lower() == 'spatial_dist':
                             outname = "{}.{}".format(outname, p.obs)
                             plot_kwargs = {
-                                "dset": p.obj,
+                                "dset": pairdf,
                                 "varname": obsvar,
                                 "outname": outname,
                                 "label": p.obs,

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -548,6 +548,12 @@ class model:
                 list_input_var = list_input_var + list(set(self.mapping[obs_map].keys()) - set(list_input_var))
         #Only certain models need this option for speeding up i/o.
 
+        # Remove standardized variable names that user may have requested to pair on or output in MM
+        # as they will be added anyway and here would cause [var_list] to fail in the below model readers.
+        for vn in ["temperature_k", "pres_pa_mid"]:
+            if vn in list_input_var:
+                list_input_var.remove(vn)
+
         if 'cmaq' in self.model.lower():
             print('**** Reading CMAQ model output...')
             self.mod_kwargs.update({'var_list' : list_input_var})

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -2732,6 +2732,8 @@ class analysis:
                                     "outname": outname,
                                     "domain_type": domain_type,
                                     "domain_name": domain_name,
+                                    "vdiff": grp_dict["data_proc"].get("vdiff", None),
+                                    "nlevels": grp_dict["data_proc"].get("nlevels", None),
                                     "fig_dict": fig_dict,
                                     "text_dict": text_dict,
                                     "debug": self.debug

--- a/melodies_monet/driver.py
+++ b/melodies_monet/driver.py
@@ -540,7 +540,7 @@ class model:
             vars_for_summing  = []
             for var in self.variable_summing.keys():
                 vars_for_summing= vars_for_summing + self.variable_summing[var]['vars']
-        list_input_var = []
+        list_input_var = list(self.variable_dict.keys()) if self.variable_dict is not None else []
         for obs_map in self.mapping:
             if self.variable_summing is not None:
                 list_input_var = list_input_var + list(set(self.mapping[obs_map].keys()).union(set(vars_for_summing)) - set(self.variable_summing.keys()) - set(list_input_var) )

--- a/melodies_monet/plots/surfplots.py
+++ b/melodies_monet/plots/surfplots.py
@@ -581,7 +581,7 @@ def make_diurnal_cycle(df, column=None, label=None, ax=None, avg_window=None, yl
     df_plot_group = df.groupby(time.hour)
     df_plot = df_plot_group.median(numeric_only=True)
     ax = df_plot[column].plot(ax=ax, legend=True, **plot_kwargs) 
-    shading_range = kwargs.get("shading_range", None)
+    shading_range = kwargs.get("shading_range", "IQR")
     if shading_range is not None:
         if shading_range not in ["IQR", "std", "total_range"]:
             raise ValueError (

--- a/melodies_monet/plots/surfplots.py
+++ b/melodies_monet/plots/surfplots.py
@@ -813,7 +813,7 @@ def make_spatial_overlay(df, vmodel, column_o=None, label_o=None, column_m=None,
     vmodel_mean = vmodel[column_m].mean(dim='time').squeeze()
     
     #Determine the domain
-    if domain_type == 'all':
+    if domain_type == 'all' and domain_name == 'CONUS':
         latmin= 25.0
         lonmin=-130.0
         latmax= 50.0
@@ -822,6 +822,12 @@ def make_spatial_overlay(df, vmodel, column_o=None, label_o=None, column_m=None,
     elif domain_type == 'epa_region' and domain_name is not None:
         latmin,lonmin,latmax,lonmax,acro = get_epa_bounds(index=None,acronym=domain_name)
         title_add = 'EPA Region ' + domain_name + ': '
+    elif domain_type.startswith('custom:') or domain_type.startswith('auto-region:'):
+        valid_data = vmodel.notnull()
+        lons = vmodel.longitude.where(valid_data)
+        lats = vmodel.latitutde.where(valid_data)
+        latmin, lonmin, latmax, lonmax = lats.min(), lons.min(), lats.max(), lons.max()
+        title_add = domain_name + ': '
     else:
         latmin= math.floor(min(df.latitude))
         lonmin= math.floor(min(df.longitude))

--- a/melodies_monet/plots/surfplots.py
+++ b/melodies_monet/plots/surfplots.py
@@ -1834,7 +1834,7 @@ def make_spatial_bias_exceedance(df, column_o=None, label_o=None, column_m=None,
             df_reg, col1=column_o+'_day', col2=column_m+'_day', map_kwargs=map_kwargs,val_max=vdiff,
             cmap="OrangeBlue", edgecolor='k',linewidth=.8)
 
-        if domain_type == 'all':
+        if domain_type == 'all' and domain_name == 'CONUS':
             latmin= 25.0
             lonmin=-130.0
             latmax= 50.0

--- a/melodies_monet/plots/surfplots.py
+++ b/melodies_monet/plots/surfplots.py
@@ -577,7 +577,7 @@ def make_diurnal_cycle(df, column=None, label=None, ax=None, avg_window=None, yl
         # plot the line
     else:
         plot_kwargs = { **dict(linestyle='-', marker='*', linewidth=1.2, markersize=6.), **plot_dict}
-    time = pd.DatetimeIndex(df["time"])
+    time = df.index
     df_plot_group = df.groupby(time.hour)
     df_plot = df_plot_group.median(numeric_only=True)
     ax = df_plot[column].plot(ax=ax, legend=True, **plot_kwargs) 

--- a/melodies_monet/plots/xarray_plots.py
+++ b/melodies_monet/plots/xarray_plots.py
@@ -1179,34 +1179,34 @@ def make_diurnal_cycle(dset, varname, ax=None, **kwargs):
     ax.set_ylabel(ylabel, **text_kwargs)
     ax.legend(fontsize=text_kwargs["fontsize"] * 0.8)
 
-    if "range_shading" in kwargs:
-        range_shading = kwargs["range_shading"]
-        if range_shading == "no":
-            pass
-        elif (range_shading not in ["total", "std", "IQR"]) and ("pct:" not in range_shading):
-            warnings.warn(
-                f"range_shading is {range_shading}, not in ['no', 'total', 'std', 'IQR'] nor 'pct:'."
-                + " Ignoring."
-            )
-        else:
-            if range_shading == "total":
-                range_max = dset_diurnal_group.max()[varname]
-                range_min = dset_diurnal_group.min()[varname]
-            elif range_shading == "std":
-                std = dset_diurnal_group.std()[varname]
-                range_max = dset_diurnal[varname] + std
-                range_min = dset_diurnal[varname] - std
-            elif range_shading == "IQR":
-                range_max = dset_diurnal_group.quantile(q=0.75)[varname]
-                range_min = dset_diurnal_group.quantile(q=0.25)[varname]
-            elif "pct:" in range_shading:
-                quantile = float(range_shading[4:]) / 100
-                upper_range = quantile + (1 - quantile) / 2
-                lower_range = (1 - quantile) / 2
-                range_max = dset_diurnal_group.quantile(upper_range)[varname]
-                range_min = dset_diurnal_group.quantile(lower_range)[varname]
-            color = p[-1].get_color()
-            ax.fill_between(dset_diurnal["hour"], range_min, range_max, alpha=0.2, color=color)
+    range_shading = kwargs.get("range_shading", "IQR")
+    range_shading = kwargs["range_shading"]
+    if range_shading == "no":
+        pass
+    elif (range_shading not in ["total", "std", "IQR"]) and ("pct:" not in range_shading):
+        warnings.warn(
+            f"range_shading is {range_shading}, not in ['no', 'total', 'std', 'IQR'] nor 'pct:'."
+            + " Ignoring."
+        )
+    else:
+        if range_shading == "total":
+            range_max = dset_diurnal_group.max()[varname]
+            range_min = dset_diurnal_group.min()[varname]
+        elif range_shading == "std":
+            std = dset_diurnal_group.std()[varname]
+            range_max = dset_diurnal[varname] + std
+            range_min = dset_diurnal[varname] - std
+        elif range_shading == "IQR":
+            range_max = dset_diurnal_group.quantile(q=0.75)[varname]
+            range_min = dset_diurnal_group.quantile(q=0.25)[varname]
+        elif "pct:" in range_shading:
+            quantile = float(range_shading[4:]) / 100
+            upper_range = quantile + (1 - quantile) / 2
+            lower_range = (1 - quantile) / 2
+            range_max = dset_diurnal_group.quantile(upper_range)[varname]
+            range_min = dset_diurnal_group.quantile(lower_range)[varname]
+        color = p[-1].get_color()
+        ax.fill_between(dset_diurnal["hour"], range_min, range_max, alpha=0.2, color=color)
     vmax = kwargs.get("vmax", None)
     vmin = kwargs.get("vmin", None)
     vmax = float(vmax) if vmax is not None else None

--- a/melodies_monet/plots/xarray_plots.py
+++ b/melodies_monet/plots/xarray_plots.py
@@ -134,8 +134,6 @@ def make_timeseries(
         plot_dict["label"] = label
     if (label is None) and (label not in plot_dict.keys()):
         plot_dict["label"] = varname
-    if vmin is not None and vmax is not None:
-        plot_dict["ylim"] = [vmin, vmax]
     # scale the fontsize for the x and y labels by the text_kwargs
     plot_dict["fontsize"] = text_kwargs["fontsize"] * 0.8
 
@@ -217,6 +215,7 @@ def make_timeseries(
     # ax.legend(frameon=False, fontsize=text_kwargs["fontsize"] * 0.8)
     ax.tick_params(axis="both", length=10.0, direction="inout")
     ax.tick_params(axis="both", which="minor", length=5.0, direction="out")
+    ax.set_ylim(vmin, vmax)
     ax.legend(
         frameon=False,
         fontsize=text_kwargs["fontsize"] * 0.8,

--- a/melodies_monet/util/region_select.py
+++ b/melodies_monet/util/region_select.py
@@ -5,8 +5,8 @@
 Masking arbitrary regions with regionmask
 """
 
-from functools import lru_cache
 import warnings
+from functools import lru_cache
 
 import pandas as pd
 
@@ -14,8 +14,8 @@ from melodies_monet.util.tools import get_epa_region_bounds, get_giorgi_region_b
 
 try:
     import geopandas as gpd
-    from shapely.geometry import MultiPolygon, Polygon
     import regionmask
+    from shapely.geometry import MultiPolygon, Polygon
 except ImportError:
     regionmask = None
 
@@ -218,8 +218,9 @@ def create_autoregion(data, domain_type, domain_name, domain_info=None):
         This is used as the region name, or to read the info.
     domain_info: None | dict[str, tuple[float, float, float, float]]
         if not None, dict containing the domain name and a tuple with
-         lonmin, lonmax, latmin, latmax. Only required if domain_type
+        lonmin, lonmax, latmin, latmax. Only required if domain_type
         is auto-region:
+
     Returns
     -------
     xr.Dataset | pd.DataFrame

--- a/melodies_monet/util/region_select.py
+++ b/melodies_monet/util/region_select.py
@@ -177,7 +177,7 @@ def control_custom_mask(data, domain_type, domain_info=None, **kwargs):
     if regionmask is None:
         raise ImportError(
             "regionmask is not installed, try alternative functions."
-                + " create_autoregion can probably do the trick."
+            + " create_autoregion can probably do the trick."
         )
     if domain_info is None:
         raise KeyError("If regionmask is used, domain_info must exist.")
@@ -218,7 +218,7 @@ def create_autoregion(data, domain_type, domain_name, domain_info=None):
         This is used as the region name, or to read the info.
     domain_info: None | dict[str, tuple[float, float, float, float]]
         if not None, dict containing the domain name and a tuple with
-        latmin, lonmin, latmax, lonmax. Only required if domain_type
+         lonmin, lonmax, latmin, latmax. Only required if domain_type
         is auto-region:
     Returns
     -------
@@ -241,18 +241,17 @@ def create_autoregion(data, domain_type, domain_name, domain_info=None):
         )
     if isinstance(data, pd.DataFrame):
         data_all = data.loc[
-            (data["latitude"] >= bounds[0])
-            & (data["longitude"] >= bounds[1])
-            & (data["latitude"] <= bounds[2])
-            & (data["longitude"] <= bounds[3])
+            (data["longitude"] >= bounds[0])
+            & (data["longitude"] <= bounds[1])
+            & (data["latitude"] >= bounds[2])
+            & (data["latitude"] <= bounds[3])
         ]
     else:
         data_all = data.where(
-            (data["latitude"] >= bounds[0])
-            & (data["longitude"] >= bounds[1])
-            & (data["latitude"] <= bounds[2])
-            & (data["longitude"] <= bounds[3]),
-            # drop=True,
+            (data["longitude"] >= bounds[0])
+            & (data["longitude"] <= bounds[1])
+            & (data["latitude"] >= bounds[2])
+            & (data["latitude"] <= bounds[3]),
         )
     return data_all
 


### PR DESCRIPTION
Two small bugfixes:

- Timeseries in `xarray_plots` and `surfplots` were not reading `vmin` and `vmax` always.
- Change the way to define `custom:box` to make it consistent with `ax.set_extent` and the `extent` keyword in maps.
- Set IQR as default in diurnal_cycle (which is the median)
- Allows to add variables not mapped nor summed to models. Essential for filtering (e.g, using the ozone tropopause)

There are still some lingering bugs:
- The labels are not really read. Need to decide on how to do it
Setting this as draft as I have not decided how to fix the bug with the labels, since we could:

1. read them from a list (in each plotgroup) in order
2. Read them from variable_dict
3. Others?
